### PR TITLE
Allow defining filter rules as array

### DIFF
--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -58,7 +58,7 @@ class Sanitizer
     {
         $parsedRules = [];
         foreach ($rules as $attribute => $attributeRules) {
-            $attributeRulesArray = explode('|', $attributeRules);
+            $attributeRulesArray = is_array($attributeRules) ? $attributeRules : explode('|', $attributeRules);
             foreach ($attributeRulesArray as $attributeRule) {
                 $parsedRule = $this->parseRuleString($attributeRule);
                 if ($parsedRule) {

--- a/tests/SanitizerTest.php
+++ b/tests/SanitizerTest.php
@@ -39,6 +39,17 @@ class SanitizerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('  HellO EverYboDy   ', $data['name']);
     }
 
+    public function test_array_filters() {
+        $data = [
+            'name' => '  HellO EverYboDy   ',
+        ];
+        $rules = [
+            'name' => ['trim', 'capitalize'],
+        ];
+        $data = $this->sanitize($data, $rules);
+        $this->assertEquals('Hello Everybody', $data['name']);
+    }
+
     /**
      *  @test
      *  @expectedException \InvalidArgumentException


### PR DESCRIPTION
As in Laravel validation rules can be defined as a string separated by | or as an array, this pull request provides similar behavior to filter rules.

So now both:
```php
$filters = [
    'first_name' => 'trim|escape|capitalize'
];
```
and
```php
$filters = [
    'first_name' => [ 'trim', 'escape', 'capitalize']
];
```
will do the same.