### PR TITLE
Limit Laravel required version to less than 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "illuminate/support": "^5.5",
+        "illuminate/support": "~5.3 <5.6",
         "nesbot/carbon": "~1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "illuminate/support": "~5.3",
+        "illuminate/support": "^5.5",
         "nesbot/carbon": "~1.0"
     },
     "require-dev": {


### PR DESCRIPTION
One of the changes in Laravel 5.6 breaks the package https://laravel.com/docs/5.6/upgrade

The validate method of the ValidatesWhenResolved interface / trait has been renamed to validateResolved in order to avoid conflicts with the $request->validate() method.

Therefore the package needs to include a composer constraint to prevent using it with Laravel 5.6.

Related issue #14 