### PR TITLE
Add support for Laravel 5.6 w/backwards compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/waavi/sanitizer.svg?style=flat-square)](https://packagist.org/packages/waavi/sanitizer)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
-[![Build Status](https://img.shields.io/travis/alariva/sanitizer/master.svg?style=flat-square)](https://travis-ci.org/alariva/sanitizer)
+[![Build Status](https://img.shields.io/travis/waavi/sanitizer/master.svg?style=flat-square)](https://travis-ci.org/alariva/sanitizer)
 [![Total Downloads](https://img.shields.io/packagist/dt/waavi/sanitizer.svg?style=flat-square)](https://packagist.org/packages/waavi/sanitizer)
 
 ## About WAAVI

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/waavi/sanitizer.svg?style=flat-square)](https://packagist.org/packages/waavi/sanitizer)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
-[![Build Status](https://img.shields.io/travis/waavi/sanitizer/master.svg?style=flat-square)](https://travis-ci.org/alariva/sanitizer)
+[![Build Status](https://img.shields.io/travis/waavi/sanitizer/master.svg?style=flat-square)](https://travis-ci.org/waavi/sanitizer)
 [![Total Downloads](https://img.shields.io/packagist/dt/waavi/sanitizer.svg?style=flat-square)](https://packagist.org/packages/waavi/sanitizer)
 
 ## About WAAVI

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/waavi/sanitizer.svg?style=flat-square)](https://packagist.org/packages/waavi/sanitizer)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
-[![Build Status](https://img.shields.io/travis/Waavi/sanitizer/master.svg?style=flat-square)](https://travis-ci.org/Waavi/sanitizer)
+[![Build Status](https://img.shields.io/travis/alariva/sanitizer/master.svg?style=flat-square)](https://travis-ci.org/alariva/sanitizer)
 [![Total Downloads](https://img.shields.io/packagist/dt/waavi/sanitizer.svg?style=flat-square)](https://packagist.org/packages/waavi/sanitizer)
 
 ## About WAAVI

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "illuminate/support": "~5.3",
+        "illuminate/support": "^5.3 || ^5.4 || ^5.5 || ^5.6",
         "nesbot/carbon": "~1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "illuminate/support": "^5.3 || ^5.4 || ^5.5 || ^5.6",
+        "illuminate/support": "~5.3",
         "nesbot/carbon": "~1.0"
     },
     "require-dev": {

--- a/src/Laravel/SanitizesInput.php
+++ b/src/Laravel/SanitizesInput.php
@@ -7,12 +7,28 @@ trait SanitizesInput
     /**
      *  Sanitize input before validating.
      *
+     *  Kept for backwards compatibility with Laravel <= 5.5
+     *  
+     *  @deprecated Renamed to validateResolved() in Laravel 5.6
      *  @return void
      */
     public function validate()
     {
         $this->sanitize();
         parent::validate();
+    }
+
+    /**
+     *  Sanitize input before validating.
+     *
+     *  Compatible with Laravel 5.6+
+     *
+     *  @return void
+     */
+    public function validateResolved()
+    {
+        $this->sanitize();
+        parent::validateResolved();
     }
 
     /**


### PR DESCRIPTION
Makes package compatible with Laravel 5.6 and keeps backwards compatibility for deprecated method.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waavi/sanitizer/21)
<!-- Reviewable:end -->
