### PR TITLE
Fix request stub to extend form request directly

### DIFF
--- a/src/Laravel/stubs/request.stub
+++ b/src/Laravel/stubs/request.stub
@@ -2,10 +2,10 @@
 
 namespace DummyNamespace;
 
-use App\Http\Requests\Request;
+use Illuminate\Foundation\Http\FormRequest;
 use Waavi\Sanitizer\Laravel\SanitizesInput;
 
-class DummyClass extends Request
+class DummyClass extends FormRequest
 {
     use SanitizesInput;
 


### PR DESCRIPTION
Hello, 

In a fresh Laravel install (5.7.19), the following command: 

```
php artisan make:sanitized-request TestSanitizedRequest
```

will generate a Form Request that extends the `App\Http\Requests\Request`. It seems, as from Laravel 5.3, this class does not exist anymore. This PR [(#14744)](https://github.com/laravel/framework/pull/14744) changed that. 

Form Requests now extend the `Illuminate\Foundation\Http\FormRequest` class directly. This PR fixes this issue in the Request stub. 

Thanks!