### PR TITLE
Added string to digit filter & tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Given a data array with the following format:
         'email'         =>  '  JOHn@DoE.com',
         'birthdate'     =>  '06/25/1980',
         'jsonVar'       =>  '{"name":"value"}',
-        'description'   =>  '<p>Test paragraph.</p><!-- Comment --> <a href="#fragment">Other text</a>'
+        'description'   =>  '<p>Test paragraph.</p><!-- Comment --> <a href="#fragment">Other text</a>',
+        'phone'         =>  '+08(096)90-123-45q',
     ];
 ```
 We can easily format it using our Sanitizer and the some of Sanitizer's default filters:
@@ -39,7 +40,8 @@ We can easily format it using our Sanitizer and the some of Sanitizer's default 
         'email'         =>  'trim|escape|lowercase',
         'birthdate'     =>  'trim|format_date:m/d/Y, Y-m-d',
         'jsonVar'       =>  'cast:array',
-        'description'   =>  'strip_tags'
+        'description'   =>  'strip_tags',
+        'phone'         =>  'digit',
     ];
 
     $sanitizer  = new Sanitizer($data, $filters);
@@ -54,7 +56,8 @@ Which will yield:
         'email'         =>  'john@doe.com',
         'birthdate'     =>  '1980-06-25',
         'jsonVar'       =>  '["name" => "value"]',
-        'description'   =>  'Test paragraph. Other text'
+        'description'   =>  'Test paragraph. Other text',
+        'phone'         =>  '080969012345',
     ];
 ```
 It's usage is very similar to Laravel's Validator module, for those who are already familiar with it, although Laravel is not required to use this library.
@@ -75,6 +78,7 @@ The following filters are available out of the box:
  **cast**           | Casts a variable into the given type. Options are: integer, float, string, boolean, object, array and Laravel Collection.
  **format_date**    | Always takes two arguments, the date's given format and the target format, following DateTime notation.
  **strip_tags**    | Strip HTML and PHP tags using php's strip_tags
+ **digit**    | Get only digit characters from the string
 
 
 ## Adding custom filters

--- a/src/Filters/Digit.php
+++ b/src/Filters/Digit.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Waavi\Sanitizer\Filters;
+
+use Waavi\Sanitizer\Contracts\Filter;
+
+class Digit implements Filter
+{
+    /**
+     *  Get only digit characters from the string.
+     *
+     *  @param  string  $value
+     *  @return string
+     */
+    public function apply($value, $options = [])
+    {
+        return preg_replace('/[^0-9]/si', '', $value);
+    }
+}

--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -34,7 +34,7 @@ class Sanitizer
         'uppercase'   => \Waavi\Sanitizer\Filters\Uppercase::class,
         'trim'        => \Waavi\Sanitizer\Filters\Trim::class,
         'strip_tags'  => \Waavi\Sanitizer\Filters\StripTags::class,
-
+        'digit'       => \Waavi\Sanitizer\Filters\Digit::class,
     ];
 
     /**

--- a/tests/Filters/DigitTest.php
+++ b/tests/Filters/DigitTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use Waavi\Sanitizer\Sanitizer;
+
+class DigitTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @param $data
+     * @param $rules
+     * @return mixed
+     */
+    public function sanitize($data, $rules)
+    {
+        $sanitizer = new Sanitizer($data, $rules);
+        return $sanitizer->sanitize();
+    }
+
+    /**
+     *  @test
+     */
+    public function it_string_to_digits()
+    {
+        $data = [
+            'name' => '+08(096)90-123-45q',
+        ];
+        $rules = [
+            'name' => 'digit',
+        ];
+        $data = $this->sanitize($data, $rules);
+        $this->assertEquals('080969012345', $data['name']);
+    }
+
+    /**
+     *  @test
+     */
+    public function it_string_to_digits2()
+    {
+        $data = [
+            'name' => 'Qwe-rty!:)',
+        ];
+        $rules = [
+            'name' => 'digit',
+        ];
+        $data = $this->sanitize($data, $rules);
+        $this->assertEquals('', $data['name']);
+    }
+}


### PR DESCRIPTION
I added a new filter for get only digit characters from any strings (for example to phone number: `+0(36)4-5 => 03645`) and unit-tests for it. Please accept my pull-request :)