### PR TITLE
Upgrade dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
     "require": {
         "illuminate/support": "~5.3",
         "illuminate/validation": "~5.3",
-        "nesbot/carbon": "~1.0"
+        "nesbot/carbon": "~1.0|~2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0"
+        "phpunit/phpunit": "~8.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
 >
     <testsuites>
         <testsuite name="Sanitizer Test Suite">

--- a/src/Laravel/SanitizesInput.php
+++ b/src/Laravel/SanitizesInput.php
@@ -23,7 +23,7 @@ trait SanitizesInput
     public function sanitize()
     {
         $this->addCustomFilters();
-        $this->sanitizer = \Sanitizer::make($this->input(), $this->filters());
+        $this->sanitizer = app('sanitizer')->make($this->input(), $this->filters());
         $this->replace($this->sanitizer->sanitize());
     }
 
@@ -35,7 +35,7 @@ trait SanitizesInput
     public function addCustomFilters()
     {
         foreach ($this->customFilters() as $name => $filter) {
-            \Sanitizer::extend($name, $filter);
+            app('sanitizer')->extend($name, $filter);
         }
     }
 

--- a/tests/CustomFilter.php
+++ b/tests/CustomFilter.php
@@ -1,5 +1,6 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Waavi\Sanitizer\Contracts\Filter;
 
 class CustomFilter implements Filter

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -1,9 +1,10 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Waavi\Sanitizer\Laravel\Factory;
 use Waavi\Sanitizer\Sanitizer;
 
-class FactoryTest extends PHPUnit_Framework_TestCase
+class FactoryTest extends TestCase
 {
     public function sanitize($data, $rules)
     {

--- a/tests/Filters/CapitalizeTest.php
+++ b/tests/Filters/CapitalizeTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Waavi\Sanitizer\Sanitizer;
 
-class CapitalizeTest extends PHPUnit_Framework_TestCase
+class CapitalizeTest extends TestCase
 {
     /**
      * @param $data

--- a/tests/Filters/CastTest.php
+++ b/tests/Filters/CastTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Waavi\Sanitizer\Sanitizer;
 
-class CastTest extends PHPUnit_Framework_TestCase
+class CastTest extends TestCase
 {
     /**
      * @param $data
@@ -17,19 +18,19 @@ class CastTest extends PHPUnit_Framework_TestCase
 
     /**
      *  @test
-     *  @expectedException \InvalidArgumentException
      */
     public function it_throws_exception_when_no_cast_type_is_set()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->sanitize(['name' => 'Name'], ['name' => 'cast']);
     }
 
     /**
      *  @test
-     *  @expectedException \InvalidArgumentException
      */
     public function it_throws_exception_when_non_existing_cast_type_is_set()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->sanitize(['name' => 'Name'], ['name' => 'cast:bullshit']);
     }
 
@@ -39,7 +40,7 @@ class CastTest extends PHPUnit_Framework_TestCase
     public function it_casts_to_integer()
     {
         $results = $this->sanitize(['var' => '15.6'], ['var' => 'cast:integer']);
-        $this->assertInternalType('int', $results['var']);
+        $this->assertIsInt($results['var']);
         $this->assertEquals(15, $results['var']);
     }
 
@@ -49,7 +50,7 @@ class CastTest extends PHPUnit_Framework_TestCase
     public function it_casts_to_float()
     {
         $results = $this->sanitize(['var' => '15.6'], ['var' => 'cast:double']);
-        $this->assertInternalType('float', $results['var']);
+        $this->assertIsFloat($results['var']);
         $this->assertEquals(15.6, $results['var']);
     }
 
@@ -59,7 +60,7 @@ class CastTest extends PHPUnit_Framework_TestCase
     public function it_casts_to_string()
     {
         $results = $this->sanitize(['var' => 15], ['var' => 'cast:string']);
-        $this->assertInternalType('string', $results['var']);
+        $this->assertIsString($results['var']);
         $this->assertEquals('15', $results['var']);
     }
 
@@ -69,7 +70,7 @@ class CastTest extends PHPUnit_Framework_TestCase
     public function it_casts_to_boolean()
     {
         $results = $this->sanitize(['var' => 15], ['var' => 'cast:boolean']);
-        $this->assertInternalType('boolean', $results['var']);
+        $this->assertIsBool($results['var']);
         $this->assertEquals(true, $results['var']);
     }
 
@@ -116,7 +117,7 @@ class CastTest extends PHPUnit_Framework_TestCase
         ];
         $encodedData = json_encode($data);
         $results     = $this->sanitize(['var' => $encodedData], ['var' => 'cast:array']);
-        $this->assertInternalType('array', $results['var']);
+        $this->assertIsArray($results['var']);
         $this->assertEquals('Name', $results['var']['name']);
         $this->assertEquals(15.6, $results['var']['cost']);
     }

--- a/tests/Filters/DigitTest.php
+++ b/tests/Filters/DigitTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Waavi\Sanitizer\Sanitizer;
 
-class DigitTest extends PHPUnit_Framework_TestCase
+class DigitTest extends TestCase
 {
     /**
      * @param $data

--- a/tests/Filters/EscapeHTMLTest.php
+++ b/tests/Filters/EscapeHTMLTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Waavi\Sanitizer\Sanitizer;
 
-class EscapeHTMLTest extends PHPUnit_Framework_TestCase
+class EscapeHTMLTest extends TestCase
 {
     /**
      * @param $data

--- a/tests/Filters/FormatDateTest.php
+++ b/tests/Filters/FormatDateTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Waavi\Sanitizer\Sanitizer;
 
-class FormatDateTest extends PHPUnit_Framework_TestCase
+class FormatDateTest extends TestCase
 {
     /**
      * @param $data
@@ -32,10 +33,10 @@ class FormatDateTest extends PHPUnit_Framework_TestCase
 
     /**
      *  @test
-     *  @expectedException \InvalidArgumentException
      */
     public function it_requires_two_arguments()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $data = [
             'name' => '21/03/1983',
         ];

--- a/tests/Filters/LowercaseTest.php
+++ b/tests/Filters/LowercaseTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Waavi\Sanitizer\Sanitizer;
 
-class LowercaseTest extends PHPUnit_Framework_TestCase
+class LowercaseTest extends TestCase
 {
     /**
      * @param $data

--- a/tests/Filters/StripTagsTest.php
+++ b/tests/Filters/StripTagsTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Waavi\Sanitizer\Sanitizer;
 
-class StripTagsTest extends PHPUnit_Framework_TestCase
+class StripTagsTest extends TestCase
 {
     /**
      * @param $data

--- a/tests/Filters/TrimTest.php
+++ b/tests/Filters/TrimTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Waavi\Sanitizer\Sanitizer;
 
-class TrimTest extends PHPUnit_Framework_TestCase
+class TrimTest extends TestCase
 {
     /**
      * @param $data

--- a/tests/Filters/UppercaseTest.php
+++ b/tests/Filters/UppercaseTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Waavi\Sanitizer\Sanitizer;
 
-class UppercaseTest extends PHPUnit_Framework_TestCase
+class UppercaseTest extends TestCase
 {
     /**
      * @param $data

--- a/tests/SanitizerTest.php
+++ b/tests/SanitizerTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
 use Waavi\Sanitizer\Sanitizer;
 
-class SanitizerTest extends PHPUnit_Framework_TestCase
+class SanitizerTest extends TestCase
 {
     /**
      * @param $data
@@ -78,11 +79,10 @@ class SanitizerTest extends PHPUnit_Framework_TestCase
 
     /**
      *  @test
-     *  @expectedException \InvalidArgumentException
      */
     public function it_throws_exception_if_non_existing_filter()
     {
-        $this->setExpectedException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $data = [
             'name' => '  HellO EverYboDy   ',
         ];


### PR DESCRIPTION
This pull requests upgrades these dependencies:

PHPUnit 4.x to PHPUnit 8.x
Support ended for PHPUnit 4 on February 3, 2017; revised all tests to use PHPUnit namespace

Carbon 1.x to Carbon 1.x|2.x
Laravel 5.8 includes support for carbon 2.x. 