### PR TITLE
Sanitize only passed data

### DIFF
--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -127,13 +127,15 @@ class Sanitizer
         $sanitized = $this->data;
 
         foreach ($this->rules as $attr => $rules) {
-            $value = Arr::get($this->data, $attr);
+            if (Arr::has($this->data, $attr)) {
+                $value = Arr::get($this->data, $attr);
 
-            foreach ($rules as $rule) {
-                $value = $this->applyFilter($rule['name'], $value, $rule['options']);
+                foreach ($rules as $rule) {
+                    $value = $this->applyFilter($rule['name'], $value, $rule['options']);
+                }
+
+                Arr::set($sanitized, $attr, $value);
             }
-
-            Arr::set($sanitized, $attr, $value);
         }
 
         return $sanitized;

--- a/tests/SanitizerTest.php
+++ b/tests/SanitizerTest.php
@@ -91,4 +91,22 @@ class SanitizerTest extends TestCase
         ];
         $data = $this->sanitize($data, $rules);
     }
+
+    public function test_it_should_only_sanitize_passed_data()
+    {
+        $data = [
+            'title' => ' Hello WoRlD '
+        ];
+
+        $rules = [
+            'title' => 'trim',
+            'name' => 'trim|escape'
+        ];
+
+        $data = $this->sanitize($data, $rules);
+
+        $this->assertArrayNotHasKey('name', $data);
+        $this->assertArrayHasKey('title', $data);
+        $this->assertEquals(1, count($data));
+    }
 }


### PR DESCRIPTION
Sanitize only passed data.

This prevent returning `null` value on filters rules that do have a data.

Currently the package returns `null` value when it should only apply filters on data passed.

This related to this issue raised: https://github.com/Waavi/Sanitizer/issues/25