### PR TITLE
Fix #48: Add array type verification before accessing index

### DIFF
--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -161,10 +161,10 @@ class Sanitizer
 
                 $sanitize = true;
                 foreach ($rules as $rule) {
-                    if ($rule['name'] === 'filter_if') {
-                        $sanitize = $this->applyFilter($rule['name'], $this->data, $rule['options']);
+                    if (is_array($rule) && $rule['name'] === 'filter_if') {
+                        $sanitize = $this->applyFilter($rule, $this->data);
                     } else {
-                        $value = $this->applyFilter($rule['name'], $value, $rule['options']);
+                        $value = $this->applyFilter($rule, $value);
                     }
                 }
 


### PR DESCRIPTION
Since the $rule may now be array as well as a Closure, the array type must be checked before trying to access indexes.
Also, `applyFilter` calls is corrected to respect it's signature.
This should fix `ErrorException Illegal string offset 'name'` being thrown.

Fixes Waavi#48

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waavi/sanitizer/49)
<!-- Reviewable:end -->
