### PR TITLE
Wildcard validation usage added to the read me file example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Which will yield:
         'jsonVar'       =>  '["name" => "value"]',
         'description'   =>  'Test paragraph. Other text',
         'phone'         =>  '080969012345',
-        'roles'         =>  ['admin','level_1_user ','level_2_user'],
+        'roles'         =>  ['admin','level_1_user','level_2_user'],
         'country'       =>  'GB',
         'postcode'      =>  'AB12 3DE',
     ];

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Given a data array with the following format:
         'jsonVar'       =>  '{"name":"value"}',
         'description'   =>  '<p>Test paragraph.</p><!-- Comment --> <a href="#fragment">Other text</a>',
         'phone'         =>  '+08(096)90-123-45q',
+        'roles'         =>  ['admin','Level_1_user ','<b>level_2_user</b>'],
         'country'       =>  'GB',
         'postcode'      =>  'ab12 3de',
     ];
@@ -44,6 +45,7 @@ We can easily format it using our Sanitizer and the some of Sanitizer's default 
         'jsonVar'       =>  'cast:array',
         'description'   =>  'strip_tags',
         'phone'         =>  'digit',
+        'roles.*'       =>  'trim|escape|lowercase',
         'country'       =>  'trim|escape|capitalize',
         'postcode'      =>  'trim|escape|uppercase|filter_if:country,GB',
     ];
@@ -62,6 +64,7 @@ Which will yield:
         'jsonVar'       =>  '["name" => "value"]',
         'description'   =>  'Test paragraph. Other text',
         'phone'         =>  '080969012345',
+        'roles'         =>  ['admin','level_1_user ','level_2_user'],
         'country'       =>  'GB',
         'postcode'      =>  'AB12 3DE',
     ];


### PR DESCRIPTION
Wildcard rules has been implemented and merged in to the master branch in this pull request [https://github.com/Waavi/Sanitizer/pull/13] about a year ago, however documentation does not have any indications/examples about how to use wildcard arrays.