### PR TITLE
Add customFilters example

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,14 @@ You may also Sanitize input in your own FormRequests by using the SanitizesInput
             return [
                 'name'  => 'trim|capitalize',
                 'email' => 'trim',
+                'text'  => 'remove_strings:Curse,Words,Galore',
+            ];
+        }
+
+        public function customFilters()
+        {
+            return [
+                'remove_strings' => RemoveStringsFilter::class,
             ];
         }
 

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,8 @@
         "email": "info@waavi.com"
     }],
     "require": {
-        "illuminate/support": "~5.3|~6.0",
-        "illuminate/validation": "~5.3|~6.0",
+        "illuminate/support": "~5.3|~6.0|^7.0",
+        "illuminate/validation": "~5.3|~6.0|^7.0",
         "nesbot/carbon": "~1.0|~2.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "waavi/sanitizer",
-    "description": "Data sanitizer and Laravel 5 form requests with input sanitation.",
+    "name": "francoism90/sanitizer",
+    "description": "Data sanitizer and Laravel 7 form requests with input sanitation.",
     "keywords": ["laravel", "sanitation", "input sanitation", "input sanitizer", "input", "transform input", "input filter"],
     "license": "MIT",
     "authors": [{
@@ -8,6 +8,7 @@
         "email": "info@waavi.com"
     }],
     "require": {
+        "php": "^7.2",
         "illuminate/support": "~5.3|~6.0|^7.0",
         "illuminate/validation": "~5.3|~6.0|^7.0",
         "nesbot/carbon": "~1.0|~2.0"
@@ -32,6 +33,9 @@
                 "Sanitizer": "Waavi\\Sanitizer\\Laravel\\Facade"
             }
         }
+    },
+    "config": {
+        "sort-packages": true
     },
     "minimum-stability": "dev",
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "francoism90/sanitizer",
+    "name": "waavi/sanitizer",
     "description": "Data sanitizer and Laravel 7 form requests with input sanitation.",
     "keywords": ["laravel", "sanitation", "input sanitation", "input sanitizer", "input", "transform input", "input filter"],
     "license": "MIT",

--- a/src/Laravel/SanitizesInput.php
+++ b/src/Laravel/SanitizesInput.php
@@ -58,7 +58,7 @@ trait SanitizesInput
     /**
      *  Filters to be applied to the input.
      *
-     *  @return void
+     *  @return array
      */
     public function filters()
     {
@@ -68,7 +68,7 @@ trait SanitizesInput
     /**
      *  Custom Filters to be applied to the input.
      *
-     *  @return void
+     *  @return array
      */
     public function customFilters()
     {


### PR DESCRIPTION
Thanks for your package. :)

CustomFilters doesn't seem to be mentioned in the Request example, I've added this to the `README.md` . The return types should also be corrected to `@return array`.